### PR TITLE
added new time format

### DIFF
--- a/time.go
+++ b/time.go
@@ -29,6 +29,8 @@ var commonTimeLayouts = []string{
 }
 
 var commonDateLayouts = []string{
+	"01-02-06",
+	"02-01-06", // This may not ever match
 	"1/2/2006",
 	"1-2-2006",
 	"01-02-2006",


### PR DESCRIPTION
This doesn't address the issue of ambiguous formats (i.e. 01-02-06 is Jan 2nd or Feb 1st?), but it will support the weird excel time format introduced via `export to excel` on Google Sheets.
